### PR TITLE
Aim at global angle

### DIFF
--- a/application/chassis_behaviour.c
+++ b/application/chassis_behaviour.c
@@ -615,7 +615,8 @@ static void chassis_cv_spinning_control(fp32 *vx_set, fp32 *vy_set, fp32 *angle_
     // }
     // else
     {
-        spinning_speed = SPINNING_CHASSIS_MED_OMEGA;
+        // spinning_speed = SPINNING_CHASSIS_MED_OMEGA;
+        spinning_speed = 0;
     }
     *angle_set = rad_format(spinning_speed * ((fp32)CHASSIS_CONTROL_TIME_MS / (fp32)configTICK_RATE_HZ) + chassis_move_rc_to_vector->chassis_relative_angle_set);
 }

--- a/application/cv_usart_task.h
+++ b/application/cv_usart_task.h
@@ -15,8 +15,8 @@
 
 typedef struct __attribute__((packed))
 {
-    fp32 xDeltaAngle; ///< unit: rad
-    fp32 yDeltaAngle; ///< unit: rad
+    fp32 xTargetAngle; ///< unit: rad
+    fp32 yTargetAngle; ///< unit: rad
     fp32 xSpeed;
     fp32 ySpeed;
 } tCvCmdMsg;
@@ -27,7 +27,8 @@ typedef enum
     CV_MODE_AUTO_MOVE_BIT = 1 << 1,
     CV_MODE_ENEMY_DETECTED_BIT = 1 << 2,
     CV_MODE_SHOOT_BIT = 1 << 3,
-    CV_MODE_LAST_BIT = 1 << 4,
+    CV_MODE_IMU_CALI_BIT = 1 << 4, ///< 1 means IMU calibration is not done yet, and gimbal is powered to held at a fixed center position
+    CV_MODE_LAST_BIT = 1 << 5,
 } eModeControlBits;
 STATIC_ASSERT(CV_MODE_LAST_BIT <= (1 << 8));
 

--- a/application/gimbal_behaviour.c
+++ b/application/gimbal_behaviour.c
@@ -256,6 +256,15 @@ static void gimbal_motionless_control(fp32 *yaw, fp32 *pitch, gimbal_control_t *
 //云台行为状态机
 gimbal_behaviour_e gimbal_behaviour = GIMBAL_ZERO_FORCE;
 
+#if GIMBAL_TEST_MODE
+fp32 yaw_ins_delta_1000;
+uint8_t gimbal_behaviour_global;
+static void J_scope_gimbal_behavior_test(void)
+{
+    gimbal_behaviour_global = gimbal_behaviour;
+}
+#endif
+
 /**
   * @brief          the function is called by gimbal_set_mode function in gimbal_task.c
   *                 the function set gimbal_behaviour variable, and set motor mode.
@@ -315,6 +324,10 @@ void gimbal_behaviour_mode_set(gimbal_control_t *gimbal_mode_set)
         gimbal_mode_set->gimbal_yaw_motor.gimbal_motor_mode = GIMBAL_MOTOR_ENCONDE;
         gimbal_mode_set->gimbal_pitch_motor.gimbal_motor_mode = GIMBAL_MOTOR_ENCONDE;
     }
+
+#if GIMBAL_TEST_MODE
+    J_scope_gimbal_behavior_test();
+#endif
 }
 
 /**
@@ -508,7 +521,7 @@ static void gimbal_behavour_set(gimbal_control_t *gimbal_mode_set)
     }
     else
     {
-        gimbal_behaviour = GIMBAL_AUTO_AIM_PATROL;
+        gimbal_behaviour = GIMBAL_AUTO_AIM;
     }
 #else
     // 开关控制 云台状态
@@ -776,15 +789,27 @@ static void gimbal_cv_control(fp32 *yaw, fp32 *pitch, gimbal_control_t *gimbal_c
         return;
     }
 
-    fp32 cv_yaw_channel = 0;
-    fp32 cv_pitch_channel = 0;
+    // Positive Directions
+    // CvCmdHandler.CvCmdMsg.xDeltaAngle: right
+    // CvCmdHandler.CvCmdMsg.yDeltaAngle: up
+    // yaw_target_adjustment : left (same direction as IMU)
+    // pitch_target_adjustment: down (same direction as IMU)
+    fp32 yaw_target_adjustment = 0;
+    fp32 pitch_target_adjustment = 0;
     if (checkAndResetFlag(&CvCmdHandler.fCvCmdValid))
     {
-        deadband_limit(CvCmdHandler.CvCmdMsg.xDeltaAngle, cv_yaw_channel, CV_CAMERA_YAW_DEADBAND);
-        deadband_limit(CvCmdHandler.CvCmdMsg.yDeltaAngle, cv_pitch_channel, CV_CAMERA_PITCH_DEADBAND);
+        yaw_target_adjustment = -CvCmdHandler.CvCmdMsg.xDeltaAngle - rad_format(gimbal_control_set->gimbal_yaw_motor.absolute_angle_set - gimbal_control_set->gimbal_yaw_motor.absolute_angle);
+        pitch_target_adjustment = -CvCmdHandler.CvCmdMsg.yDeltaAngle - rad_format(gimbal_control_set->gimbal_pitch_motor.absolute_angle_set - gimbal_control_set->gimbal_pitch_motor.absolute_angle);
     }
-    *yaw = moving_average_calc(cv_yaw_channel, &(gimbal_control_set->gimbal_yaw_motor.CvCmdAngleFilter), MOVING_AVERAGE_CALC);
-    *pitch = moving_average_calc(cv_pitch_channel, &(gimbal_control_set->gimbal_pitch_motor.CvCmdAngleFilter), MOVING_AVERAGE_CALC);
+    // brakeband_limit(yaw_target_adjustment, yaw_target_adjustment, CV_CAMERA_YAW_BRAKEBAND);
+    // brakeband_limit(pitch_target_adjustment, pitch_target_adjustment, CV_CAMERA_PITCH_BRAKEBAND);
+    // *yaw = moving_average_calc(yaw_target_adjustment, &(gimbal_control_set->gimbal_yaw_motor.CvCmdAngleFilter), MOVING_AVERAGE_CALC);
+    // *pitch = moving_average_calc(pitch_target_adjustment, &(gimbal_control_set->gimbal_pitch_motor.CvCmdAngleFilter), MOVING_AVERAGE_CALC);
+    *yaw = yaw_target_adjustment;
+    *pitch = pitch_target_adjustment;
+#if GIMBAL_TEST_MODE
+    yaw_ins_delta_1000 = yaw_target_adjustment * 1000;
+#endif
 }
 
 /**

--- a/application/gimbal_task.c
+++ b/application/gimbal_task.c
@@ -984,21 +984,20 @@ static void gimbal_set_control(gimbal_control_t *set_control)
   */
 static void gimbal_absolute_angle_limit(gimbal_motor_t *gimbal_motor, fp32 add, uint8_t motor_select)
 {
-    static fp32 bias_angle;
     if (gimbal_motor == NULL)
     {
         return;
     }
-    //now angle error
-    //当前控制误差角度
-    bias_angle = rad_format(gimbal_motor->absolute_angle_set - gimbal_motor->absolute_angle);
-    //relative angle + angle error + add_angle > max_relative angle
-    //云台相对角度+ 误差角度 + 新增角度 如果大于 最大机械角度
 #if (ROBOT_TYPE == INFANTRY_2018_MECANUM) || (ROBOT_TYPE == INFANTRY_2023_MECANUM) || (ROBOT_TYPE == INFANTRY_2023_SWERVE) || (ROBOT_TYPE == SENTRY_2023_MECANUM)
     // Remove yaw motor limit for robots with slip ring
     if (motor_select != GIMBAL_YAW_MOTOR)
 #endif
     {
+        //now angle error
+        //当前控制误差角度
+        fp32 bias_angle = rad_format(gimbal_motor->absolute_angle_set - gimbal_motor->absolute_angle);
+        //relative angle + angle error + add_angle > max_relative angle
+        //云台相对角度+ 误差角度 + 新增角度 如果大于 最大机械角度
         if (gimbal_motor->relative_angle + bias_angle + add > gimbal_motor->max_relative_angle)
         {
             // 如果是往最大机械角度控制方向

--- a/application/gimbal_task.h
+++ b/application/gimbal_task.h
@@ -174,6 +174,7 @@
 #define PITCH_MOUSE_SEN 0.00005f
 
 #define GIMBAL_CONTROL_TIME 1
+#define MS_TO_SEC 1000.0f
 
 //test mode, 0 close, 1 open
 //云台测试模式 宏定义 0 为不使用测试模式


### PR DESCRIPTION
This work is based on branch cv/Auto_aim, so cv/Auto_aim must merge before cv/Aim_global_angle merges.

Originally we aim incrementally by the angle difference between target and camera heading angle, the better "global angle" approach is to aim at target that is coordinated within world (game arena) frame.