### PR TITLE
Reset setpoint to angle when setpoint is more than pi ahead of angle

### DIFF
--- a/application/chassis_task.h
+++ b/application/chassis_task.h
@@ -156,7 +156,7 @@
 #define CHASSIS_FOLLOW_GIMBAL_PID_KP 12.0f
 #define CHASSIS_FOLLOW_GIMBAL_PID_KI 0.0f
 #define CHASSIS_FOLLOW_GIMBAL_PID_KD 0.1f
-#define CHASSIS_FOLLOW_GIMBAL_PID_MAX_OUT 6.0f
+#define CHASSIS_FOLLOW_GIMBAL_PID_MAX_OUT 10.0f
 #define CHASSIS_FOLLOW_GIMBAL_PID_MAX_IOUT 0.2f
 
 typedef enum
@@ -213,7 +213,6 @@ typedef struct
   fp32 vx_set;                      //chassis set vertical speed,positive means forward,unit m/s.底盘设定速度 前进方向 前为正，单位 m/s
   fp32 vy_set;                      //chassis set horizontal speed,positive means left,unit m/s.底盘设定速度 左右方向 左为正，单位 m/s
   fp32 wz_set;                      //chassis set rotation speed,positive means counterclockwise,unit rad/s.底盘设定旋转角速度，逆时针为正 单位 rad/s
-  fp32 chassis_relative_angle;      //the relative angle between chassis and gimbal.底盘与云台的相对角度，单位 rad
   fp32 chassis_relative_angle_set;  //the set relative angle.设置相对云台控制角度
   fp32 chassis_yaw_set;             
 


### PR DESCRIPTION
Reset setpoint to angle when setpoint is more than pi ahead of angle. When setpoint is more than pi ahead of angle, `rad_format(chassis_move_control->chassis_relative_angle_set - chassis_move_control->chassis_relative_angle)` should return a negative number because of the loop constrain that rad format applies, causing the reset to happen.