### PR TITLE
Restrict chassis power by varying speed target

### DIFF
--- a/application/chassis_power_control.c
+++ b/application/chassis_power_control.c
@@ -22,22 +22,22 @@
 #include "detect_task.h"
 #include "chassis_task.h"
 
-#define WARNING_POWER_RATIO 0.7f
-#define POWER_BUFF_TOTAL 60.0f
-#if (ROBOT_TYPE == INFANTRY_2023_SWERVE)
-#define WARNING_POWER_BUFF (POWER_BUFF_TOTAL / 2.0f)
-#else
-#define WARNING_POWER_BUFF (POWER_BUFF_TOTAL / 3.0f)
-#endif
-#define NO_JUDGE_TOTAL_CURRENT_LIMIT (MAX_3508_MOTOR_CAN_CURRENT * 4.0f)
+// #define WARNING_POWER_RATIO 0.7f
+// #define POWER_BUFF_TOTAL 60.0f
+// #if (ROBOT_TYPE == INFANTRY_2023_SWERVE)
+// #define WARNING_POWER_BUFF (POWER_BUFF_TOTAL / 2.0f)
+// #else
+// #define WARNING_POWER_BUFF (POWER_BUFF_TOTAL / 3.0f)
+// #endif
+// #define NO_JUDGE_TOTAL_CURRENT_LIMIT (MAX_3508_MOTOR_CAN_CURRENT * 4.0f)
 
-#define M3508_CURRENT_TO_POWER_RATIO 0.025f // power is approx 25V * 1/1000 mA
-#define M3508_CURRENT_TO_POWER(_current) ((_current) * M3508_CURRENT_TO_POWER_RATIO)
-#define M3508_POWER_TO_CURRENT(_power) ((_power) / M3508_CURRENT_TO_POWER_RATIO)
-// assumption of time that power stay unchanged despite command changes
-#define M3508_POWER_CONTROL_DELAY_S (0.1f)
-#define M3508_POWER_CONTROL_SHRINKED_DELAY_S (M3508_POWER_CONTROL_DELAY_S / 2.0f)
-#define CURRENT_LIMIT_FILTER_COEFF 0.3f
+// #define M3508_CURRENT_TO_POWER_RATIO 0.025f // power is approx 25V * 1/1000 mA
+// #define M3508_CURRENT_TO_POWER(_current) ((_current) * M3508_CURRENT_TO_POWER_RATIO)
+// #define M3508_POWER_TO_CURRENT(_power) ((_power) / M3508_CURRENT_TO_POWER_RATIO)
+// // assumption of time that power stay unchanged despite command changes
+// #define M3508_POWER_CONTROL_DELAY_S (0.1f)
+// #define M3508_POWER_CONTROL_SHRINKED_DELAY_S (M3508_POWER_CONTROL_DELAY_S / 2.0f)
+// #define CURRENT_LIMIT_FILTER_COEFF 0.3f
 
 /**
   * @brief          limit the power, mainly limit driver motor current
@@ -46,82 +46,82 @@
   */
 void chassis_power_control(chassis_move_t *chassis_power_control)
 {
-    static fp32 total_current_limit = 0;
-    if (toe_is_error(REFEREE_TOE) || (get_robot_id() == 0))
-    {
-        total_current_limit = NO_JUDGE_TOTAL_CURRENT_LIMIT;
-    }
-    else
-    {
-        fp32 chassis_power;
-        fp32 chassis_power_buffer;
-        fp32 chassis_power_limit;
-        fp32 cap_voltage = cap_message_rx.cap_message.cap_milivoltage / 1000.0f;
-        get_chassis_power_data(&chassis_power, &chassis_power_buffer, &chassis_power_limit);
+    // static fp32 total_current_limit = 0;
+    // if (toe_is_error(REFEREE_TOE) || (get_robot_id() == 0))
+    // {
+    //     total_current_limit = NO_JUDGE_TOTAL_CURRENT_LIMIT;
+    // }
+    // else
+    // {
+    //     fp32 chassis_power;
+    //     fp32 chassis_power_buffer;
+    //     fp32 chassis_power_limit;
+    //     fp32 cap_voltage = cap_message_rx.cap_message.cap_milivoltage / 1000.0f;
+    //     get_chassis_power_data(&chassis_power, &chassis_power_buffer, &chassis_power_limit);
 
-        // Not use supercap
-        if (toe_is_error(SUPCAP_TOE) || (cap_voltage <= SUPCAP_VOLTAGE_LOWER_USE_THRESHOLD))
-        {
-            // Avoid windup after power being limited
-            // @TODO: fix unsynchronization issue of M3508 speed after power limiter is triggered
-            if (chassis_power_control->motor_speed_pid[0].max_iout != 0)
-            {
-                for (uint8_t i = 0; i < 4; i++)
-                {
-                    chassis_power_control->motor_speed_pid[i].max_iout = 0;
-                    chassis_power_control->motor_speed_pid[i].Kp = M3508_MOTOR_SPEED_PID_KP * 0.8f;
-                }
-            }
+    //     // Not use supercap
+    //     if (toe_is_error(SUPCAP_TOE) || (cap_voltage <= SUPCAP_VOLTAGE_LOWER_USE_THRESHOLD))
+    //     {
+    //         // Avoid windup after power being limited
+    //         // @TODO: fix unsynchronization issue of M3508 speed after power limiter is triggered
+    //         if (chassis_power_control->motor_speed_pid[0].max_iout != 0)
+    //         {
+    //             for (uint8_t i = 0; i < 4; i++)
+    //             {
+    //                 chassis_power_control->motor_speed_pid[i].max_iout = 0;
+    //                 chassis_power_control->motor_speed_pid[i].Kp = M3508_MOTOR_SPEED_PID_KP * 0.8f;
+    //             }
+    //         }
 
-            fp32 raw_current_limit = M3508_POWER_TO_CURRENT(chassis_power_limit / M3508_POWER_CONTROL_DELAY_S);
-            if (chassis_power_buffer >= WARNING_POWER_BUFF)
-            {
-                if ((chassis_power <= (chassis_power_limit * WARNING_POWER_RATIO)) || (chassis_power_control->chassis_RC->key.v & KEY_PRESSED_OFFSET_SHIFT))
-                {
-                    raw_current_limit += M3508_POWER_TO_CURRENT(chassis_power_buffer / M3508_POWER_CONTROL_SHRINKED_DELAY_S);
-                }
-                else
-                {
-                    raw_current_limit += M3508_POWER_TO_CURRENT(chassis_power_buffer / M3508_POWER_CONTROL_DELAY_S);
-                }
-            }
-            else
-            {
-                raw_current_limit = M3508_POWER_TO_CURRENT(chassis_power_buffer / M3508_POWER_CONTROL_DELAY_S);
-            }
-            total_current_limit = first_order_filter(raw_current_limit, total_current_limit, CURRENT_LIMIT_FILTER_COEFF);
-        }
-        // Use supercap
-        else
-        {
-            // turn back integral term
-            if (chassis_power_control->motor_speed_pid[0].max_iout == 0)
-            {
-                for (uint8_t i = 0; i < 4; i++)
-                {
-                    chassis_power_control->motor_speed_pid[i].max_iout = M3508_MOTOR_SPEED_PID_MAX_IOUT;
-                    chassis_power_control->motor_speed_pid[i].Kp = M3508_MOTOR_SPEED_PID_KP;
-                }
-            }
-            total_current_limit = NO_JUDGE_TOTAL_CURRENT_LIMIT;
-        }
-    }
+    //         fp32 raw_current_limit = M3508_POWER_TO_CURRENT(chassis_power_limit / M3508_POWER_CONTROL_DELAY_S);
+    //         if (chassis_power_buffer >= WARNING_POWER_BUFF)
+    //         {
+    //             if ((chassis_power <= (chassis_power_limit * WARNING_POWER_RATIO)) || (chassis_power_control->chassis_RC->key.v & KEY_PRESSED_OFFSET_SHIFT))
+    //             {
+    //                 raw_current_limit += M3508_POWER_TO_CURRENT(chassis_power_buffer / M3508_POWER_CONTROL_SHRINKED_DELAY_S);
+    //             }
+    //             else
+    //             {
+    //                 raw_current_limit += M3508_POWER_TO_CURRENT(chassis_power_buffer / M3508_POWER_CONTROL_DELAY_S);
+    //             }
+    //         }
+    //         else
+    //         {
+    //             raw_current_limit = M3508_POWER_TO_CURRENT(chassis_power_buffer / M3508_POWER_CONTROL_DELAY_S);
+    //         }
+    //         total_current_limit = first_order_filter(raw_current_limit, total_current_limit, CURRENT_LIMIT_FILTER_COEFF);
+    //     }
+    //     // Use supercap
+    //     else
+    //     {
+    //         // turn back integral term
+    //         if (chassis_power_control->motor_speed_pid[0].max_iout == 0)
+    //         {
+    //             for (uint8_t i = 0; i < 4; i++)
+    //             {
+    //                 chassis_power_control->motor_speed_pid[i].max_iout = M3508_MOTOR_SPEED_PID_MAX_IOUT;
+    //                 chassis_power_control->motor_speed_pid[i].Kp = M3508_MOTOR_SPEED_PID_KP;
+    //             }
+    //         }
+    //         total_current_limit = NO_JUDGE_TOTAL_CURRENT_LIMIT;
+    //     }
+    // }
 
-    fp32 total_current = 0.0f;
-    //calculate the original motor current set
-    for(uint8_t i = 0; i < 4; i++)
-    {
-        total_current += fabs(chassis_power_control->motor_speed_pid[i].out);
-    }
+    // fp32 total_current = 0.0f;
+    // //calculate the original motor current set
+    // for(uint8_t i = 0; i < 4; i++)
+    // {
+    //     total_current += fabs(chassis_power_control->motor_speed_pid[i].out);
+    // }
     
 
-    if(total_current > total_current_limit)
-    {
-        // only limit current of driver motors, because power usage by steering motors is small and difficult to estimate. Because we control voltage input to steering motor (GM6020), not current
-        fp32 current_scale = total_current_limit / total_current;
-        chassis_power_control->motor_speed_pid[0].out*=current_scale;
-        chassis_power_control->motor_speed_pid[1].out*=current_scale;
-        chassis_power_control->motor_speed_pid[2].out*=current_scale;
-        chassis_power_control->motor_speed_pid[3].out*=current_scale;
-    }
+    // if(total_current > total_current_limit)
+    // {
+    //     // only limit current of driver motors, because power usage by steering motors is small and difficult to estimate. Because we control voltage input to steering motor (GM6020), not current
+    //     fp32 current_scale = total_current_limit / total_current;
+    //     chassis_power_control->motor_speed_pid[0].out*=current_scale;
+    //     chassis_power_control->motor_speed_pid[1].out*=current_scale;
+    //     chassis_power_control->motor_speed_pid[2].out*=current_scale;
+    //     chassis_power_control->motor_speed_pid[3].out*=current_scale;
+    // }
 }

--- a/application/custom_ui_task.c
+++ b/application/custom_ui_task.c
@@ -20,6 +20,7 @@
 #include "AHRS_middleware.h"
 #include "chassis_behaviour.h"
 #include "chassis_power_control.h"
+#include "chassis_task.h"
 #include "cmsis_os.h"
 #include "gimbal_behaviour.h"
 #include "gimbal_task.h"
@@ -249,18 +250,26 @@ void chassis_mode_draw(void)
 		}
 		case CHASSIS_SPINNING:
 		{
-			char_draw(&robot_status_str, "robot_status_str", UI_Graph_Change, 8, UI_Color_Pink, 20, 4, 3, 930, 227, "SPIN");
-			update_char(&robot_status_str);
-			char_draw(&rand_spin_str, "rand_spin_str", (chassis_move.fRandomSpinOn ? UI_Graph_Del : UI_Graph_ADD), 8, UI_Color_Pink, 20, 4, 3, 930, 187, "RAND");
-			update_char(&rand_spin_str);
+			if(chassis_move.fRandomSpinOn)
+			{
+				char_draw(&robot_status_str, "robot_status_str", UI_Graph_Change, 8, UI_Color_Pink, 20, 4, 3, 930, 227, "SPIN");
+				update_char(&robot_status_str);
+				char_draw(&rand_spin_str, "rand_spin_str", UI_Graph_ADD, 8, UI_Color_Pink, 20, 4, 3, 930, 187, "RAND");
+				update_char(&rand_spin_str);
+			}
+			else
+			{
+				char_draw(&robot_status_str, "robot_status_str", UI_Graph_Change, 8, UI_Color_Pink, 20, 4, 3, 930, 227, "SPIN");
+				update_char(&robot_status_str);
+				char_draw(&rand_spin_str, "rand_spin_str", UI_Graph_Del, 8, UI_Color_Pink, 20, 4, 3, 930, 187, "RAND");
+				update_char(&rand_spin_str);
+			}
 			break;
+			
 		}
 		default:
 		{
-			char_draw(&robot_status_str, "robot_status_str", UI_Graph_Change, 8, UI_Color_Pink, 20, 4, 3, 930, 227, "STOP");
-			update_char(&robot_status_str);
-			char_draw(&rand_spin_str, "rand_spin_str", UI_Graph_Del, 8, UI_Color_Pink, 20, 4, 3, 930, 187, "RAND");
-			update_char(&rand_spin_str);
+			
 			break;
 		}
 	}


### PR DESCRIPTION
New Strategy:
- Let user choose whether to use super cap. If "Shift" not pressed, restrict speed target so that buffer is not used by much (<50%), otherwise, restrict buffer use to about 80% within about 0.75 second.
- Limit chassis power by reducing speed target without changing internal pid parameters, otherwise, speeds of motors won't be synchronized and will tear body apart.